### PR TITLE
remove outdated `$ depth` utility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,6 @@ RUN apt update && apt install -y zip \
 	&& wget https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protoc-3.17.3-linux-x86_64.zip \
 	&& unzip protoc-3.17.3-linux-x86_64.zip && mv bin/protoc /usr/local/bin/ && cd / && rm -rf /tmp/protoc \
 	&& ln -s /workspace/gohack /root/gohack \
-	&& curl --fail --location -o /go/bin/depth https://github.com/KyleBanks/depth/releases/download/v1.2.1/depth_1.2.1_linux_amd64 \
-	&& chmod +x /go/bin/depth \
 	&& curl --fail --location https://function61.com/app-dl/api/github.com/golangci/golangci-lint/latest_releases_asset/golangci-lint-%2A-linux-amd64.tar.gz \
 		| tar --strip-components=1 -C /usr/local/bin -xzf - --wildcards 'golangci-lint-*-linux-amd64/golangci-lint' \
 	&& rm -rf /go/pkg \


### PR DESCRIPTION
it doesn't seem to work with the "new" Go modules ecosystem